### PR TITLE
use attributes instead of wlid

### DIFF
--- a/containerscan/datastructuresmethods.go
+++ b/containerscan/datastructuresmethods.go
@@ -29,15 +29,13 @@ func (layer *ScanResultLayer) GetPackagesNames() []string {
 }
 
 // GenerateBogusHash - generate the old (bogus) hash for the workload
-func GenerateBogusHash(wlid string) string {
-	context := armotypes.AttributesDesignatorsFromWLID(wlid).Attributes
+func GenerateBogusHash(context map[string]string) string {
 	context[armotypes.AttributeNamespace] = ""
 	return generateWorkloadHash(context)
 }
 
 // GenerateWorkloadHash - generate a hash for the workload
-func GenerateWorkloadHash(wlid string) string {
-	context := armotypes.AttributesDesignatorsFromWLID(wlid).Attributes
+func GenerateWorkloadHash(context map[string]string) string {
 	return generateWorkloadHash(context)
 }
 

--- a/containerscan/datastructuresmethods_test.go
+++ b/containerscan/datastructuresmethods_test.go
@@ -8,48 +8,68 @@ import (
 
 func TestGenerateBogusHash(t *testing.T) {
 	tests := []struct {
-		name string
-		wlid string
-		want string
+		name       string
+		attributes map[string]string
+		want       string
 	}{
 		{
 			name: "kube-proxy",
-			wlid: "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy",
+			attributes: map[string]string{
+				"cluster":   "minikube",
+				"namespace": "kube-system",
+				"kind":      "daemonset",
+				"name":      "kube-proxy",
+			},
 			want: "5485464254446115801",
 		},
 		{
 			name: "coredns",
-			wlid: "wlid://cluster-bez-longrun3/namespace-kube-system/deployment-coredns",
+			attributes: map[string]string{
+				"cluster":   "bez-longrun3",
+				"namespace": "kube-system",
+				"kind":      "deployment",
+				"name":      "coredns",
+			},
 			want: "16878991644547272844",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, GenerateBogusHash(tt.wlid), "GenerateWorkloadHash(%v)", tt.wlid)
+			assert.Equalf(t, tt.want, GenerateBogusHash(tt.attributes), "GenerateWorkloadHash(%v)", tt.attributes)
 		})
 	}
 }
 
 func TestGenerateWorkloadHash(t *testing.T) {
 	tests := []struct {
-		name string
-		wlid string
-		want string
+		name       string
+		attributes map[string]string
+		want       string
 	}{
 		{
 			name: "kube-proxy",
-			wlid: "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy",
+			attributes: map[string]string{
+				"cluster":   "minikube",
+				"namespace": "kube-system",
+				"kind":      "daemonset",
+				"name":      "kube-proxy",
+			},
 			want: "8248822369989173472",
 		},
 		{
 			name: "coredns",
-			wlid: "wlid://cluster-bez-longrun3/namespace-kube-system/deployment-coredns",
+			attributes: map[string]string{
+				"cluster":   "bez-longrun3",
+				"namespace": "kube-system",
+				"kind":      "deployment",
+				"name":      "coredns",
+			},
 			want: "12836087988784946749",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, GenerateWorkloadHash(tt.wlid), "GenerateWorkloadHash(%v)", tt.wlid)
+			assert.Equalf(t, tt.want, GenerateWorkloadHash(tt.attributes), "GenerateWorkloadHash(%v)", tt.attributes)
 		})
 	}
 }


### PR DESCRIPTION
use attributes instead of wlid for generating workload hash. The main consumer of this function is the BE aggregator, which sometimes has `wlid` as an empty string, but always has the designators attributes in place 