### PR TITLE
move flag

### DIFF
--- a/containerscan/commonContainerScanSummaryResultMethods.go
+++ b/containerscan/commonContainerScanSummaryResultMethods.go
@@ -148,3 +148,11 @@ func (summary *CommonContainerScanSummaryResult) SetVersion(version string) {
 func (summary *CommonContainerScanSummaryResult) SetTimestamp(timestamp int64) {
 	summary.Timestamp = timestamp
 }
+
+func (summary *CommonContainerScanSummaryResult) GetHasRelevancyData() bool {
+	return summary.HasRelevancyData
+}
+
+func (summary *CommonContainerScanSummaryResult) SetHasRelevancyData(hasRelevancy bool) {
+	summary.HasRelevancyData = hasRelevancy
+}

--- a/containerscan/commonContainerScanSummaryResultMethods_test.go
+++ b/containerscan/commonContainerScanSummaryResultMethods_test.go
@@ -237,3 +237,15 @@ func TestGetSeverityStats(t *testing.T) {
 	assert.Equal(t, int64(15), stats.TotalCount)
 	assert.Equal(t, "critical", stats.Severity)
 }
+
+func TestGetHasRelevancyData(t *testing.T) {
+	reportWithRelevancy := CommonContainerScanSummaryResult{HasRelevancyData: true}
+	if !reportWithRelevancy.GetHasRelevancyData() {
+		t.Error("Expected GetHasRelevancyData() to return true for a ScanResultReportV1 with relevancy data, but it returned false")
+	}
+
+	reportWithoutRelevancy := CommonContainerScanSummaryResult{HasRelevancyData: false}
+	if reportWithoutRelevancy.GetHasRelevancyData() {
+		t.Error("Expected GetHasRelevancyData() to return false for a ScanResultReportV1 without relevancy data, but it returned true")
+	}
+}

--- a/containerscan/commondatastructures.go
+++ b/containerscan/commondatastructures.go
@@ -97,4 +97,5 @@ type CommonContainerScanSummaryResult struct {
 	Timestamp                     int64                      `json:"timestamp"`
 	ImageSignatureValid           bool                       `json:"imageSignatureValid,omitempty"`
 	ImageHasSignature             bool                       `json:"imageHasSignature,omitempty"`
+	HasRelevancyData              bool                       `json:"hasRelevancyData"`
 }

--- a/containerscan/interfaces.go
+++ b/containerscan/interfaces.go
@@ -16,7 +16,6 @@ type ScanReport interface {
 	GetVulnerabilities() []ContainerScanVulnerabilityResult
 	GetVersion() string
 	GetPaginationInfo() apis.PaginationMarks
-	GetHasRelevancyData() bool
 	Validate() bool
 
 	SetDesignators(armotypes.PortalDesignator)
@@ -46,6 +45,7 @@ type ContainerScanSummaryResult interface {
 	GetTimestamp() int64
 	GetJobIDs() []string
 	Validate() bool
+	GetHasRelevancyData() bool
 
 	SetDesignators(armotypes.PortalDesignator)
 	SetContext([]armotypes.ArmoContext)
@@ -64,6 +64,7 @@ type ContainerScanSummaryResult interface {
 	SetCustomerGUID(string)
 	SetContainerScanID(string)
 	SetTimestamp(int64)
+	SetHasRelevancyData(bool)
 }
 
 type ContainerScanVulnerabilityResult interface {

--- a/containerscan/v1/datastructures.go
+++ b/containerscan/v1/datastructures.go
@@ -7,11 +7,10 @@ import (
 )
 
 type ScanResultReport struct {
-	Designators      armotypes.PortalDesignator                         `json:"designators"`
-	Summary          *containerscan.CommonContainerScanSummaryResult    `json:"summary,omitempty"`
-	ContainerScanID  string                                             `json:"containersScanID"`
-	Vulnerabilities  []containerscan.CommonContainerVulnerabilityResult `json:"vulnerabilities"`
-	PaginationInfo   apis.PaginationMarks                               `json:"paginationInfo"`
-	Timestamp        int64                                              `json:"timestamp"`
-	HasRelevancyData bool                                               `json:"hasRelevancyData"`
+	Designators     armotypes.PortalDesignator                         `json:"designators"`
+	Summary         *containerscan.CommonContainerScanSummaryResult    `json:"summary,omitempty"`
+	ContainerScanID string                                             `json:"containersScanID"`
+	Vulnerabilities []containerscan.CommonContainerVulnerabilityResult `json:"vulnerabilities"`
+	PaginationInfo  apis.PaginationMarks                               `json:"paginationInfo"`
+	Timestamp       int64                                              `json:"timestamp"`
 }

--- a/containerscan/v1/scanResultReportMethods.go
+++ b/containerscan/v1/scanResultReportMethods.go
@@ -43,10 +43,6 @@ func (r *ScanResultReport) GetSummary() containerscan.ContainerScanSummaryResult
 	return r.Summary
 }
 
-func (r *ScanResultReport) GetHasRelevancyData() bool {
-	return r.HasRelevancyData
-}
-
 func (r *ScanResultReport) GetVulnerabilities() []containerscan.ContainerScanVulnerabilityResult {
 	var vulnerabilities []containerscan.ContainerScanVulnerabilityResult
 	for _, vul := range r.Vulnerabilities {
@@ -111,8 +107,7 @@ func (scan *ScanResultReport) UnmarshalJSONObject(dec *gojay.Decoder, key string
 		err = dec.String(&(scan.ContainerScanID))
 	case "designators":
 		err = dec.Object(&(scan.Designators))
-	case "hasRelevancyData":
-		err = dec.Bool(&(scan.HasRelevancyData))
+
 	}
 	return err
 }

--- a/containerscan/v1/scanResultReportMethods_test.go
+++ b/containerscan/v1/scanResultReportMethods_test.go
@@ -117,20 +117,7 @@ func TestScanResultReportDecoding(t *testing.T) {
 	assert.Equal(t, "deployment", scanReport.Designators.Attributes[armotypes.AttributeKind])
 	assert.Equal(t, "e57ec5a0-695f-4777-8366-1c64fada00a0", scanReport.Designators.Attributes[armotypes.AttributeCustomerGUID])
 	assert.Equal(t, "myContainer", scanReport.Designators.Attributes[armotypes.AttributeContainerName])
-	assert.Equal(t, false, scanReport.HasRelevancyData)
 
-}
-
-func TestGetHasRelevancyData(t *testing.T) {
-	reportWithRelevancy := ScanResultReport{HasRelevancyData: true}
-	if !reportWithRelevancy.GetHasRelevancyData() {
-		t.Error("Expected GetHasRelevancyData() to return true for a ScanResultReportV1 with relevancy data, but it returned false")
-	}
-
-	reportWithoutRelevancy := ScanResultReport{HasRelevancyData: false}
-	if reportWithoutRelevancy.GetHasRelevancyData() {
-		t.Error("Expected GetHasRelevancyData() to return false for a ScanResultReportV1 without relevancy data, but it returned true")
-	}
 }
 
 func TestSetContainerScanID(t *testing.T) {


### PR DESCRIPTION
Move `HasRelevancyData` flag from `ScanResultReport` to `CommonContainerScanSummaryResult` (since this is the one being saved on db)